### PR TITLE
Remove maxSdkVersion from vibration permission

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -11,8 +11,7 @@
         android:protectionLevel="signature" />
     <uses-permission android:name="${applicationId}.permission.C2D_MESSAGE" />
 
-    <!-- Ref: http://stackoverflow.com/questions/13602190/java-lang-securityexception-requires-vibrate-permission-on-jelly-bean-4-2 -->
-    <uses-permission android:name="android.permission.VIBRATE" android:maxSdkVersion="18" />
+    <uses-permission android:name="android.permission.VIBRATE" />
 
     <application>
 


### PR DESCRIPTION
This line causes issues when the app consuming this library is targeting higher SDK versions.

(made a fork and opened this PR as I couldn't open an issue on this repo. :P) 